### PR TITLE
casting timestamps to ints

### DIFF
--- a/cortex/feature_types.py
+++ b/cortex/feature_types.py
@@ -141,8 +141,8 @@ def raw_feature(name, dependencies):
             HZ_THRESH = 0.5 # set threshold in hz
             idx = 0
             if len(_event['data']) > 0:
-                end_time = _event['data'][0]['timestamp']
-                start_time = _event['data'][len(_event['data'])-1]['timestamp']
+                end_time = int(_event['data'][0]['timestamp'])
+                start_time = int(_event['data'][len(_event['data'])-1]['timestamp'])
                 res_counts = np.zeros((len(range(end_time, start_time, -1 * RES))))
                 if res_counts.shape[0] > 0:
                     for i, x in enumerate(range(end_time, start_time, -1 * RES)):

--- a/cortex/raw/accelerometer.py
+++ b/cortex/raw/accelerometer.py
@@ -34,4 +34,4 @@ def accelerometer(resolution=None, limit=20000, cache=True, recursive=True, **kw
         if not data_next: break
         if data_next[-1]['timestamp'] == to: break
         data += data_next
-    return [{'timestamp': x['timestamp'], **x['data']} for x in data]
+    return [{'timestamp': int(x['timestamp']), **x['data']} for x in data]

--- a/cortex/run.py
+++ b/cortex/run.py
@@ -11,7 +11,7 @@ import altair as alt
 import LAMP
 import cortex.raw as raw
 import cortex.secondary as secondary
-from cortex.feature_types import all_features
+from cortex.feature_types import all_features, log
 
 
 # Convenience to avoid extra imports/time-mangling nonsense...
@@ -20,6 +20,8 @@ def now():
 
 # Convenience to avoid mental math...
 MS_PER_DAY = 86400000 # (1000 ms * 60 sec * 60 min * 24 hr * 1 day)
+
+
 
 
 def run(id_or_set, features=[], feature_params={}, start=None, end=None,


### PR DESCRIPTION
Fixes an issue with getting quality metrics if timestamps are floats instead of ints.