### PR TITLE
fixing quality metrics

### DIFF
--- a/cortex/feature_types.py
+++ b/cortex/feature_types.py
@@ -141,8 +141,8 @@ def raw_feature(name, dependencies):
             HZ_THRESH = 0.5 # set threshold in hz
             idx = 0
             if len(_event['data']) > 0:
-                end_time = int(_event['data'][0]['timestamp'])
-                start_time = int(_event['data'][len(_event['data'])-1]['timestamp'])
+                end_time = kwargs["end"]# int(_event['data'][0]['timestamp'])
+                start_time = kwargs["start"]# int(_event['data'][len(_event['data'])-1]['timestamp'])
                 res_counts = np.zeros((len(range(end_time, start_time, -1 * RES))))
                 if res_counts.shape[0] > 0:
                     for i, x in enumerate(range(end_time, start_time, -1 * RES)):


### PR DESCRIPTION
Data quality metrics were artificially inflated because the start and end time were set to the start and end of the raw data instead of the start and end of the window. Therefore, people with a few clusters of very dense data could have high frequencies even though averaged over time they had very few samples. 