### PR TITLE
type casting for attachments

### DIFF
--- a/cortex/feature_types.py
+++ b/cortex/feature_types.py
@@ -320,17 +320,17 @@ def raw_feature(name, dependencies):
             data_next = []
             data = LAMP.SensorEvent.all_by_participant(kwgs['id'],
                                                origin=name,
-                                               _from=kwgs['start'],
-                                               to=kwgs['end'],
-                                               _limit=kwgs['_limit'])['data']
+                                               _from=int(kwgs['start']),
+                                               to=int(kwgs['end']),
+                                               _limit=int(kwgs['_limit']))['data']
             while (kwgs['recursive'] and
                    (len(data) == MAX_RETURN_SIZE) or len(data_next) == MAX_RETURN_SIZE):
                 to = data[-1]['timestamp']
                 data_next = LAMP.SensorEvent.all_by_participant(kwgs['id'],
                                                         origin=name,
-                                                        _from=kwgs['start'],
-                                                        to=to,
-                                                        _limit=kwgs['_limit'])['data']
+                                                        _from=int(kwgs['start']),
+                                                        to=int(to),
+                                                        _limit=int(kwgs['_limit']))['data']
                 data += data_next
 
             return [{'timestamp': x['timestamp'], **x['data']} for x in data]

--- a/cortex/primary/sleep_periods.py
+++ b/cortex/primary/sleep_periods.py
@@ -132,7 +132,7 @@ def sleep_periods(attach=True,
             # set attachment
             LAMP.Type.set_attachment(kwargs['id'], 'me',
                                      attachment_key='cortex.sleep_periods.reduced',
-                                     body={'end': kwargs['end'],
+                                     body={'end': int(kwargs['end']),
                                            'data': save_reduced_data})
             log.info("Saving reduced data...")
 


### PR DESCRIPTION
Fixing an error where some parameters need to be cast to ints in order to be passed to the API to generate an attachment. Fixed a related error getting raw data when cache=False.