### PR TITLE
adding healthkit sleep

### DIFF
--- a/cortex/raw/sleep.py
+++ b/cortex/raw/sleep.py
@@ -1,0 +1,36 @@
+""" Module for raw feature sleep """
+from ..feature_types import raw_feature
+
+
+@raw_feature(
+    name="lamp.sleep",
+    dependencies=["lamp.sleep"]
+)
+def sleep(_limit=10000,
+          cache=False,
+          recursive=False,
+          **kwargs):
+    """ Get all Healthkit sleep data bounded by time interval.
+
+    Args:
+        _limit (int): The maximum number of sensor events to query for in a single request
+        cache (bool): Indicates whether to save raw data locally in cache dir
+        recursive (bool): if True, continue requesting data until all data is
+                returned; else just one request
+
+    Returns:
+        timestamp (int): The UTC timestamp for the sleep event.
+        value (int): The sleep data.
+
+    Example:
+         [{'timestamp': 1639056600436, 'value': 0,
+         'source': 'com.apple.health.2D434BA3-4071-48C5-92BD-3598288D58A1',
+         'representation': 'in_bed', 'duration': 23987436.727046967},
+         {'timestamp': 1638970235252, 'value': 0,
+         'source': 'com.apple.health.2D434BA3-4071-48C5-92BD-3598288D58A1',
+         'representation': 'in_bed', 'duration': 3252.686023712158},
+         {'timestamp': 1638970228000, 'value': 0,
+         'source': 'com.apple.health.2D434BA3-4071-48C5-92BD-3598288D58A1',
+         'representation': 'in_bed', 'duration': 23767000}]
+    """
+    return

--- a/cortex/secondary/healthkit_sleep_duration.py
+++ b/cortex/secondary/healthkit_sleep_duration.py
@@ -1,0 +1,41 @@
+""" Module to compute healthkit sleep duration from raw feature sleep """
+import pandas as pd
+
+from ..feature_types import secondary_feature, log
+from ..raw.sleep import sleep
+
+MS_IN_A_DAY = 86400000
+@secondary_feature(
+    name='cortex.feature.healthkit_sleep_duration',
+    dependencies=[sleep]
+)
+def healthkit_sleep_duration(duration_type="in_bed", **kwargs):
+    """Time spent in bed (from healthkit).
+
+    Args:
+        **kwargs:
+            id (string): The participant's LAMP id. Required.
+            start (int): The initial UNIX timestamp (in ms) of the window for which the feature
+                is being generated. Required.
+            end (int): The last UNIX timestamp (in ms) of the window for which the feature
+                is being generated. Required.
+        duration_type (str): "in_bed", "in_sleep", or "in_awake"
+
+    Returns:
+        A dict consisting:
+            timestamp (int): The beginning of the window (same as kwargs['start']).
+            value (float): The time in bed (or asleep or awake) (in ms).
+    """
+    _sleep = sleep(**kwargs)['data']
+    if duration_type not in ["in_bed", "in_sleep", "in_awake"]:
+        log.info(f"{duration_type} is not valid. Please choose from in_bed, in_sleep, or in_awake. Returning None.")
+        return {'timestamp': kwargs['start'], 'value': None}
+
+    _sleep = [x for x in _sleep if x["representation"] == duration_type]
+    if len(_sleep) == 0:
+        return {'timestamp': kwargs['start'], 'value': None}
+
+    _sleep = pd.DataFrame(_sleep)
+    # Remove duplicates
+    _sleep = _sleep[_sleep['timestamp'] != _sleep['timestamp'].shift()]
+    return {'timestamp': kwargs['start'], 'value': _sleep["duration"].sum()}

--- a/cortex/secondary/sleep_duration.py
+++ b/cortex/secondary/sleep_duration.py
@@ -1,4 +1,4 @@
-from ..feature_types import secondary_feature, log
+from ..feature_types import secondary_feature
 from ..primary.sleep_periods import sleep_periods
 
 import math 

--- a/cortex/secondary/survey_results.py
+++ b/cortex/secondary/survey_results.py
@@ -1,4 +1,4 @@
-from ..feature_types import secondary_feature, log
+from ..feature_types import secondary_feature
 from ..primary.survey_scores import survey_scores
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Adding "lamp.sleep" as a raw feature and healthkit sleep as a secondary feature. Pulls either "in_bed", "in_sleep", or "in_awake" durations. For an inital exploration, it seems that many users do not have sleep data and of those that do most have "in_bed" data.