### PR TITLE
Adding question-wise scoring

### DIFF
--- a/cortex/primary/survey_scores.py
+++ b/cortex/primary/survey_scores.py
@@ -10,6 +10,7 @@ from ..raw.survey import survey
     dependencies=[survey]
 )
 def survey_scores(scoring_dict,
+                  return_ind_ques=False,
                   attach=False,
                   **kwargs):
     """
@@ -32,6 +33,8 @@ def survey_scores(scoring_dict,
                 map to a dictionary: give the name of the dictionary (ex: "map0",
                     and create a corresponding dictionary in the scoring_dict)
                 Non-numeric scores are not supported at this time.
+        return_ind_ques (boolean): Whether or not to return individual question scores (or just
+                    the total category score)
         attach (boolean): Indicates whether to use LAMP.Type.attachments in calculating the feature.
         **kwargs:
             id (string): The participant's LAMP id. Required.
@@ -77,16 +80,21 @@ def survey_scores(scoring_dict,
                 val = score_question(temp["value"], temp["item"], scoring_dict)
                 if val is not None:
                     if ques_info["category"] not in ret0:
-                        ret0[ques_info["category"]] = {"timestamp": s["timestamp"], "value": 0}
-                    ret0[ques_info["category"]]["value"] += val
+                        ret0[ques_info["category"]] = {"timestamp": s["timestamp"], ques_info["category"]: 0}
+                    ret0[ques_info["category"]][ques_info["category"]] += val
+                    if return_ind_ques:
+                        ret0[ques_info["category"]][temp["item"]] = val
         for k in ret0.keys():
             if len(ret0[k]) > 0:
-                ret.append({
-                    "start": ret0[k]["timestamp"],
-                    "end": survey_end_time,
-                    "category": k,
-                    "score": ret0[k]["value"],
-                })
+                for j in ret0[k]:
+                    if j != "timestamp":
+                        ret.append({
+                            "start": ret0[k]["timestamp"],
+                            "end": survey_end_time,
+                            "category": k,
+                            "question": j,
+                            "score": ret0[k][j],
+                        })
     return {'data': ret,
             'has_raw_data': has_raw_data}
 

--- a/cortex/secondary/survey_results.py
+++ b/cortex/secondary/survey_results.py
@@ -7,7 +7,7 @@ import pandas as pd
     name="cortex.survey_results",
     dependencies=[survey_scores]
 )
-def survey_results(category, **kwargs):
+def survey_results(question_or_category, **kwargs):
     """ Returns the survey scores binned by resolution for a
         certain survey category.
 
@@ -18,7 +18,8 @@ def survey_results(category, **kwargs):
                 which the feature is being generated. Required.
             end (int): The last UNIX timestamp (in ms) of the window for
                 which the feature is being generated. Required.
-        category (str): The category to bin scores. SHould be in scoring_dict.
+        question_or_category (str): The category / question to bin scores.
+                Should be in scoring_dict.
 
     Returns:
         A dict consisting:
@@ -28,5 +29,5 @@ def survey_results(category, **kwargs):
     all_scores = pd.DataFrame(survey_scores(**kwargs)['data'])
     survey_avg = None
     if len(all_scores) > 0:
-        survey_avg = all_scores[all_scores["question"] == category]["score"].mean()
+        survey_avg = all_scores[all_scores["question"] == question_or_category]["score"].mean()
     return {'timestamp': kwargs['start'], 'value': survey_avg}

--- a/cortex/secondary/survey_results.py
+++ b/cortex/secondary/survey_results.py
@@ -28,5 +28,5 @@ def survey_results(category, **kwargs):
     all_scores = pd.DataFrame(survey_scores(**kwargs)['data'])
     survey_avg = None
     if len(all_scores) > 0:
-        survey_avg = all_scores[all_scores["category"] == category]["score"].mean()
+        survey_avg = all_scores[all_scores["question"] == category]["score"].mean()
     return {'timestamp': kwargs['start'], 'value': survey_avg}


### PR DESCRIPTION
Added a flag in survey_scoring that returns individual question scores as well as overall category scores. Essentially, the returned data will be a category, question (the same as the category for overall scores), and the score.

survey_results will still return the average for a category (or a question).