### PR TITLE
Updating game scoring

### DIFF
--- a/cortex/primary/survey_scores.py
+++ b/cortex/primary/survey_scores.py
@@ -1,7 +1,5 @@
 """ Module for computing survey scores """
 from itertools import groupby
-import numpy as np
-import LAMP
 from ..feature_types import primary_feature, log
 from ..raw.survey import survey
 
@@ -18,15 +16,16 @@ def survey_scores(scoring_dict,
 
     Args:
         scoring_dict (dict): Maps survey questions to categories, for scoring.
-            Must have keys: "category_list": [list of category strings]
-                            "questions": {
-                                "question text": {"category": something from list, "scoring": type of scoring},
-                            }
-                            "map0": {
-                                "none": 0,
-                                "some": 1,
-                                "all": 2
-                            }
+            Must have keys: 
+            "category_list": [list of category strings]
+            "questions": {
+                "question text": {"category": something from list, "scoring": type of scoring},
+            }
+            "map0": {
+                "none": 0,
+                "some": 1,
+                "all": 2
+            }
             Types of scoring:
                 "value": will cast the result to an int
                 "boolean": "Yes" --> 1, "No" --> 0
@@ -38,9 +37,9 @@ def survey_scores(scoring_dict,
         attach (boolean): Indicates whether to use LAMP.Type.attachments in calculating the feature.
         **kwargs:
             id (string): The participant's LAMP id. Required.
-            start (int): The initial UNIX timestamp (in ms) of the window for which the feature 
+            start (int): The initial UNIX timestamp (in ms) of the window for which the feature
                 is being generated. Required.
-            end (int): The last UNIX timestamp (in ms) of the window for which the feature 
+            end (int): The last UNIX timestamp (in ms) of the window for which the feature
                 is being generated. Required.
 
     Returns:
@@ -73,17 +72,18 @@ def survey_scores(scoring_dict,
                 continue
             if (temp["item"] not in scoring_dict["questions"] or
                 (temp["item"] in scoring_dict["questions"]
-                 and scoring_dict["questions"][temp["item"]]["category"] not in scoring_dict["category_list"])):
+                 and scoring_dict["questions"][temp["item"]]["category"]
+                 not in scoring_dict["category_list"])):
                 continue
-            else:
-                ques_info = scoring_dict["questions"][temp["item"]]
-                val = score_question(temp["value"], temp["item"], scoring_dict)
-                if val is not None:
-                    if ques_info["category"] not in ret0:
-                        ret0[ques_info["category"]] = {"timestamp": s["timestamp"], ques_info["category"]: 0}
-                    ret0[ques_info["category"]][ques_info["category"]] += val
-                    if return_ind_ques:
-                        ret0[ques_info["category"]][temp["item"]] = val
+            ques_info = scoring_dict["questions"][temp["item"]]
+            val = score_question(temp["value"], temp["item"], scoring_dict)
+            if val is not None:
+                if ques_info["category"] not in ret0:
+                    ret0[ques_info["category"]] = {"timestamp": s["timestamp"],
+                                                   ques_info["category"]: 0}
+                ret0[ques_info["category"]][ques_info["category"]] += val
+                if return_ind_ques:
+                    ret0[ques_info["category"]][temp["item"]] = val
         for k in ret0.keys():
             if len(ret0[k]) > 0:
                 for j in ret0[k]:
@@ -125,7 +125,9 @@ def score_question(val, ques, scoring_dict):
         if val in scoring_dict[ques_info["scoring"]]:
             mapped_val = scoring_dict[ques_info["scoring"]][val]
         else:
-            log.info("*" + val + "* is not in the scoring key " + ques_info["scoring"] + " for question *" + ques + "* please try again.")
+            log.info("*" + val + "* is not in the scoring key "
+                     + ques_info["scoring"] + " for question *"
+                     + ques + "* please try again.")
             return None
         return mapped_val
     log.info("Scoring type is not valid. Please try again.")

--- a/cortex/raw/balloon_risk.py
+++ b/cortex/raw/balloon_risk.py
@@ -1,0 +1,30 @@
+""" Module for raw feature balloon risk """
+import LAMP
+from ..feature_types import raw_feature
+
+
+@raw_feature(
+    name="lamp.balloon_risk",
+    dependencies=["lamp.balloon_risk"]
+)
+def balloon_risk(_limit=10000,
+             cache=False,
+             recursive=True,
+             **kwargs):
+    """ Get balloon risk data bounded by time interval.
+
+    Args:
+        _limit (int): The maximum number of sensor events to query for in a single request
+        cache (bool): Indicates whether to save raw data locally in cache dir
+        recursive (bool): if True, continue requesting data until all data is
+                returned; else just one request
+
+    Returns:
+        timestamp (int): The UTC timestamp for the event.
+        duration (int): the duration in ms
+        activity (str): the activity id
+        static_data (dict): a dict which holds game information.
+        temporal_slices (list): list of dicts which include information
+            for each attempt
+    """
+    return

--- a/cortex/raw/cats_and_dogs.py
+++ b/cortex/raw/cats_and_dogs.py
@@ -1,0 +1,29 @@
+""" Module for raw feature cats_and_dogs """
+import LAMP
+from ..feature_types import raw_feature
+
+@raw_feature(
+    name="lamp.cats_and_dogs",
+    dependencies=["lamp.cats_and_dogs"]
+)
+def cats_and_dogs(_limit=10000,
+             cache=False,
+             recursive=True,
+             **kwargs):
+    """ Get cats_and_dogs data bounded by time interval.
+
+    Args:
+        _limit (int): The maximum number of sensor events to query for in a single request
+        cache (bool): Indicates whether to save raw data locally in cache dir
+        recursive (bool): if True, continue requesting data until all data is
+                returned; else just one request
+
+    Returns:
+        timestamp (int): The UTC timestamp for the event.
+        duration (int): the duration in ms
+        activity (str): the activity id
+        static_data (dict): a dict which includes game information
+        temporal_slices (list): list of dicts which include the 'duration',
+                'item', 'level', 'status', and 'value' for each attempt
+    """
+    return

--- a/cortex/raw/jewels_a.py
+++ b/cortex/raw/jewels_a.py
@@ -23,7 +23,6 @@ def jewels_a(_limit=10000,
         timestamp (int): The UTC timestamp for the jewels_a event.
         duration (int): the duration in ms
         activity (str): the activity id
-        activity_name (str): 'lamp.jewels_a'
         static_data (dict): a dict which includes 'point', 'score', 'total_attempts',
                 'total_bonus_collected', 'total_jewels_collected'
         temporal_slices (list): list of dicts which include the 'duration',
@@ -32,8 +31,7 @@ def jewels_a(_limit=10000,
     Example:
         [{'timestamp': 1621490047833,
           'duration': 90184,
-          'activity': 'p05jxcyxhb3wtcw4aazx',
-          'activity_name': 'lamp.jewels_a',
+          'activity': 'p05jxcyxhb3wtcw4zx',
           'static_data': {'point': 1,
                           'score': 100,
                           'total_attempts': 4,
@@ -46,38 +44,4 @@ def jewels_a(_limit=10000,
               {'duration': 613, 'item': 4, 'level': 1, 'status': True, 'value': None}]
         }],
     """
-    jewels_a_ids = [activity['id'] for activity in
-                    LAMP.Activity.all_by_participant(kwargs['id'])['data']
-                    if activity['spec'] == 'lamp.jewels_a']
-
-    _jewels_a = [{'timestamp': res['timestamp'],
-                  'duration': res['duration'],
-                  'activity': res['activity'],
-                  'activity_name': 'lamp.jewels_a',
-                  'static_data': res['static_data'],
-                  'temporal_slices': res['temporal_slices']}
-                 for res in LAMP.ActivityEvent.all_by_participant(kwargs['id'],
-                                                                  _from=kwargs['start'],
-                                                                  to=kwargs['end'],
-                                                                  _limit=_limit)['data']
-                 if res['activity'] in jewels_a_ids]
-
-    while _jewels_a and recursive:
-        _to = _jewels_a[-1]['timestamp']
-        _jewels_a_next = [{'timestamp': res['timestamp'],
-                           'duration': res['duration'],
-                           'activity':res['activity'],
-                           'activity_name':'lamp.jewels_a',
-                           'static_data':res['static_data'],
-                           'temporal_slices':res['temporal_slices']}
-                          for res in LAMP.ActivityEvent.all_by_participant(kwargs['id'],
-                                                                           _from=kwargs['start'],
-                                                                           to=_to,
-                                                                           _limit=_limit)['data']
-                          if res['activity'] in jewels_a_ids]
-
-        if not _jewels_a_next: break
-        if _jewels_a_next[-1]['timestamp'] == _to: break
-        _jewels_a += _jewels_a_next
-
-    return _jewels_a
+    return

--- a/cortex/raw/jewels_b.py
+++ b/cortex/raw/jewels_b.py
@@ -19,10 +19,9 @@ def jewels_b(_limit=10000,
                 returned; else just one request
 
     Returns:
-        timestamp (int): The UTC timestamp for the jewels_a event.
+        timestamp (int): The UTC timestamp for the jewels event.
         duration (int): the duration in ms
         activity (str): the activity id
-        activity_name (str): 'lamp.jewels_b'
         static_data (dict): a dict which includes 'point', 'score', 'total_attempts',
                 'total_bonus_collected', 'total_jewels_collected'
         temporal_slices (list): list of dicts which include the 'duration',
@@ -32,7 +31,6 @@ def jewels_b(_limit=10000,
         [{'timestamp': 1621490047833,
           'duration': 90184,
           'activity': 'p05jxcyxhb3wtcw4aazx',
-          'activity_name': 'lamp.jewels_b',
           'static_data': {'point': 1,
                           'score': 100,
                           'total_attempts': 4,
@@ -45,38 +43,4 @@ def jewels_b(_limit=10000,
               {'duration': 613, 'item': 4, 'level': 1, 'status': True, 'value': None}]
         }],
     """
-    jewels_b_ids = [activity['id'] for activity in
-                    LAMP.Activity.all_by_participant(kwargs['id'])['data']
-                    if activity['spec'] == 'lamp.jewels_b']
-
-    _jewels_b = [{'timestamp': res['timestamp'],
-                  'duration': res['duration'],
-                  'activity': res['activity'],
-                  'activity_name': 'lamp.jewels_b',
-                  'static_data': res['static_data'],
-                  'temporal_slices': res['temporal_slices']}
-                 for res in LAMP.ActivityEvent.all_by_participant(kwargs['id'],
-                                                                  _from=kwargs['start'],
-                                                                  to=kwargs['end'],
-                                                                  _limit=_limit)['data']
-                 if res['activity'] in jewels_b_ids]
-
-    while _jewels_b and recursive:
-        _to = _jewels_b[-1]['timestamp']
-        _jewels_b_next = [{'timestamp': res['timestamp'],
-                           'duration': res['duration'],
-                           'activity':res['activity'],
-                           'activity_name':'lamp.jewels_b',
-                           'static_data':res['static_data'],
-                           'temporal_slices':res['temporal_slices']}
-                          for res in LAMP.ActivityEvent.all_by_participant(kwargs['id'],
-                                                                           _from=kwargs['start'],
-                                                                           to=_to,
-                                                                           _limit=_limit)['data']
-                          if res['activity'] in jewels_b_ids]
-
-        if not _jewels_b_next: break
-        if _jewels_b_next[-1]['timestamp'] == _to: break
-        _jewels_b += _jewels_b_next
-
-    return _jewels_b
+    return

--- a/cortex/raw/pop_the_bubbles.py
+++ b/cortex/raw/pop_the_bubbles.py
@@ -1,0 +1,30 @@
+""" Module for raw feature pop_the_bubbles """
+import LAMP
+from ..feature_types import raw_feature
+
+
+@raw_feature(
+    name="lamp.pop_the_bubbles",
+    dependencies=["lamp.pop_the_bubbles"]
+)
+def pop_the_bubbles(_limit=10000,
+             cache=False,
+             recursive=True,
+             **kwargs):
+    """ Get pop_the_bubbles data bounded by time interval.
+
+    Args:
+        _limit (int): The maximum number of sensor events to query for in a single request
+        cache (bool): Indicates whether to save raw data locally in cache dir
+        recursive (bool): if True, continue requesting data until all data is
+                returned; else just one request
+
+    Returns:
+        timestamp (int): The UTC timestamp for the pop_the_bubbles event.
+        duration (int): the duration in ms
+        activity (str): the activity id
+        static_data (dict): a dict which includes game information
+        temporal_slices (list): list of dicts which include the 'duration',
+                'item', 'level', 'status', and 'value' for each attempt
+    """
+    return

--- a/cortex/raw/spatial_span.py
+++ b/cortex/raw/spatial_span.py
@@ -1,0 +1,30 @@
+""" Module for raw feature spatial_span """
+import LAMP
+from ..feature_types import raw_feature
+
+
+@raw_feature(
+    name="lamp.spatial_span",
+    dependencies=["lamp.spatial_span"]
+)
+def spatial_span(_limit=10000,
+             cache=False,
+             recursive=True,
+             **kwargs):
+    """ Get spatial_span data bounded by time interval.
+
+    Args:
+        _limit (int): The maximum number of sensor events to query for in a single request
+        cache (bool): Indicates whether to save raw data locally in cache dir
+        recursive (bool): if True, continue requesting data until all data is
+                returned; else just one request
+
+    Returns:
+        timestamp (int): The UTC timestamp for the spatial_span event.
+        duration (int): the duration in ms
+        activity (str): the activity id
+        static_data (dict): a dict which includes game information
+        temporal_slices (list): list of dicts which include the 'duration',
+                'item', 'level', 'status', and 'value' for each attempt
+    """
+    return

--- a/cortex/secondary/game_results.py
+++ b/cortex/secondary/game_results.py
@@ -1,0 +1,38 @@
+""" Module for averaging results for each game """
+from ..feature_types import secondary_feature
+from ..primary.game_level_scores import game_level_scores
+
+@secondary_feature(
+    name="cortex.game_results",
+    dependencies=[game_level_scores]
+)
+def game_results(name_of_game, **kwargs):
+    """ Returns the average game results.
+
+    Args:
+        **kwargs:
+            id (string): The participant's LAMP id. Required.
+            start (int): The initial UNIX timestamp (in ms) of the window for
+                which the feature is being generated. Required.
+            end (int): The last UNIX timestamp (in ms) of the window for
+                which the feature is being generated. Required.
+        name_of_game (str): The name of the game to return average scores.
+
+    Returns:
+        A dict consisting:
+            timestamp (int): The beginning of the window (same as kwargs['start']).
+            value (float): The average score for this game.
+                For cats_and_dogs, spatial_span, jewels_a, jewels_b: average tap time (ms)
+                For balloon_risk: average number of pumps
+                For pop_the_bubbles: average percent correct of no-go trials
+    """
+    all_scores = game_level_scores(name_of_game=name_of_game, **kwargs)['data']
+    game_avg = None
+    if len(all_scores) > 0:
+        if "avg_tap_time" in all_scores[0]:
+            game_avg = sum([x["avg_tap_time"] for x in all_scores]) / len(all_scores)
+        elif "avg_NO_go_perc_correct" in all_scores[0]:
+            game_avg = sum([x["avg_NO_go_perc_correct"] for x in all_scores]) / len(all_scores)
+        elif "avg_pumps" in all_scores[0]:
+            game_avg = sum([x["avg_pumps"] for x in all_scores]) / len(all_scores)
+    return {'timestamp': kwargs['start'], 'value': game_avg}

--- a/cortex/secondary/survey_results.py
+++ b/cortex/secondary/survey_results.py
@@ -1,7 +1,7 @@
+""" Module for computing average survey scores """
+import pandas as pd
 from ..feature_types import secondary_feature
 from ..primary.survey_scores import survey_scores
-import numpy as np
-import pandas as pd
 
 @secondary_feature(
     name="cortex.survey_results",

--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -55,10 +55,13 @@ echo "${green} sleep_periods.py ${reset}"
 pylint cortex/primary/sleep_periods.py
 echo "${green} acc_jerk.py ${reset}"
 pylint cortex/primary/acc_jerk.py
+echo "${green} survey_scores.py ${reset}"
+pylint cortex/primary/survey_scores.py
+echo "${green} game_level_scores.py ${reset}"
+pylint cortex/primary/game_level_scores.py
 
 echo "${red}----------------------------------${reset}"
 echo "${red} Running pylint for secondary features ${reset}"
-# TODO: add these
 echo "${green} bluetooth_device_count.py ${reset}"
 pylint cortex/secondary/bluetooth_device_count.py
 echo "${green} call_degree.py ${reset}"
@@ -85,5 +88,9 @@ echo "${green} trip_duration.py ${reset}"
 pylint cortex/secondary/trip_duration.py
 echo "${green} trip_distance.py ${reset}"
 pylint cortex/secondary/trip_distance.py
+echo "${green} survey_results.py ${reset}"
+pylint cortex/secondary/survey_results.py
+echo "${green} game_results.py ${reset}"
+pylint cortex/secondary/game_results.py
 
 echo "${reset}"


### PR DESCRIPTION
Raw:
- Changed the structure so that raw data for games is simply what is returned from LAMP.ActivityEvent
- Added in all games: cats_and_dogs, balloon_risk, pop_the_bubbles, jewels_a, jewels_b, spatial_span

Primary
- Return scores for each level of each game played. Start timestamps are identical for all levels of the game, so these can be used to group by game if desired.
- Tap time is used as the score metric for cats_and_dogs, jewels_a, jewels_b, spatial_span
- Average pumps is the score metric for balloon_risk
- Average percent of no-go trials correct is the metric for pop_the_bubbles
- Of course, these metrics can be changed in the future if a better scoring metric is determined.

Secondary
- The secondary feature returns the average of the level scores for each game.

I will update docs to reflect these changes once the PR is merged.