### PR TITLE
Removing lamp.connect

### DIFF
--- a/cortex/feature_types.py
+++ b/cortex/feature_types.py
@@ -17,6 +17,14 @@ import numpy as np
 import pandas as pd
 import yaml
 import LAMP
+# Connect to the LAMP API server.
+# Environment variables are required to run cortex.
+if not 'LAMP_ACCESS_KEY' in os.environ or not 'LAMP_SECRET_KEY' in os.environ:
+    raise Exception("You must configure `LAMP_ACCESS_KEY` and `LAMP_SECRET_KEY`"
+                    + " (and optionally `LAMP_SERVER_ADDRESS`) to use Cortex.")
+LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
+            os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
+
 # Get a universal logger to share with all feature functions.
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG,
                     format="[%(levelname)s:%(module)s:%(funcName)s] %(message)s")
@@ -91,13 +99,6 @@ def raw_feature(name, dependencies):
 
             if kwargs['start'] > kwargs['end']:
                 raise Exception("'start' argument must occur before 'end'.")
-
-            # Connect to the LAMP API server.
-            if not 'LAMP_ACCESS_KEY' in os.environ or not 'LAMP_SECRET_KEY' in os.environ:
-                raise Exception("You configure `LAMP_ACCESS_KEY` and `LAMP_SECRET_KEY`" +
-                                " (and optionally `LAMP_SERVER_ADDRESS`) to use Cortex.")
-            LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
-                         os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
 
             # Find a valid local cache directory
             # Get defaults
@@ -496,13 +497,6 @@ def primary_feature(name, dependencies):
             if kwargs['start'] > kwargs['end']:
                 raise Exception("'start' argument must occur before 'end'.")
 
-            # Connect to the LAMP API server.
-            if not 'LAMP_ACCESS_KEY' in os.environ or not 'LAMP_SECRET_KEY' in os.environ:
-                raise Exception("You must configure `LAMP_ACCESS_KEY` and `LAMP_SECRET_KEY`"
-                                + " (and optionally `LAMP_SERVER_ADDRESS`) to use Cortex.")
-            LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
-                        os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
-
             log.info(f"Processing primary feature \"{name}\"...")
             # TODO: Require primary feature dependencies to be raw features!
             # -> Update: Not require but add a param to allow direct 2ndary to be calculated or not
@@ -750,13 +744,6 @@ def secondary_feature(name, dependencies):
             if kwargs['start'] > kwargs['end']:
                 raise Exception("'start' argument must occur before 'end'.")
 
-            # Connect to the LAMP API server.
-            if not 'LAMP_ACCESS_KEY' in os.environ or not 'LAMP_SECRET_KEY' in os.environ:
-                raise Exception("You must configure `LAMP_ACCESS_KEY` and `LAMP_SECRET_KEY`"
-                                + " (and optionally `LAMP_SERVER_ADDRESS`) to use Cortex.")
-            LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
-                        os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
-
             log.info("Processing secondary feature " + name + "...")
             def _get_default_args(func):
                 """ Get the default arguments for the function.
@@ -810,8 +797,6 @@ def delete_attach(participant, features=None):
     :param participant (str): LAMP id to reset for
     :param features (list): features to reset, defaults to all features (optional)
     """
-    LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
-                 os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
     attachments= LAMP.Type.list_attachments(participant)['data']
     if features is None: features=attachments
     for feature in attachments:

--- a/cortex/primary/significant_locations.py
+++ b/cortex/primary/significant_locations.py
@@ -141,7 +141,7 @@ def _location_duration(df, cluster):
         Args:
             df_cluster (pd.DataFrame): The original dataframe of GPS reads.
             cluster (int): The cluster index (i.e. rank).
-            
+
         Returns:
             A float, duration in that cluster (in ms).
     """
@@ -164,13 +164,13 @@ def _location_duration(df, cluster):
 def _significant_locations_kmeans(k_max=10, eps=1e-5, **kwargs):
     """Function to return significant locations using kmeans
         clustering.
-        
+
         Args:
             k_max (int): The maximum number of clusters ot use.
             eps (float): The maximum distance separating points in the
                 same cluster.
             **kwargs:
-            
+
         Returns:
     """
     # Get DB scan metadata fir

--- a/cortex/primary/sleep_periods.py
+++ b/cortex/primary/sleep_periods.py
@@ -16,18 +16,18 @@ def sleep_periods(attach=True,
                   **kwargs):
     """
     Generate sleep periods with given data
-    
+
     Args:
-        attach (boolean): 
+        attach (boolean):
         **kwargs:
             id (string): The participant's LAMP id. Required.
             start (int): The initial UNIX timestamp (in ms) of the window for which the feature 
                 is being generated. Required.
             end (int): The last UNIX timestamp (in ms) of the window for which the feature 
                 is being generated. Required.
-                
+
     Returns:
-        
+
     """
     def _expected_sleep_period(accelerometer_data_reduced):
         """

--- a/cortex/raw/balloon_risk.py
+++ b/cortex/raw/balloon_risk.py
@@ -1,5 +1,4 @@
 """ Module for raw feature balloon risk """
-import LAMP
 from ..feature_types import raw_feature
 
 

--- a/cortex/raw/cats_and_dogs.py
+++ b/cortex/raw/cats_and_dogs.py
@@ -1,5 +1,4 @@
 """ Module for raw feature cats_and_dogs """
-import LAMP
 from ..feature_types import raw_feature
 
 @raw_feature(

--- a/cortex/raw/jewels_a.py
+++ b/cortex/raw/jewels_a.py
@@ -1,7 +1,5 @@
 """ Module for raw feature jewels_a """
-import LAMP
 from ..feature_types import raw_feature
-
 
 @raw_feature(
     name="lamp.jewels_a",

--- a/cortex/raw/jewels_b.py
+++ b/cortex/raw/jewels_b.py
@@ -1,5 +1,4 @@
 """ Module for raw feature jewels_b """
-import LAMP
 from ..feature_types import raw_feature
 
 @raw_feature(

--- a/cortex/raw/pop_the_bubbles.py
+++ b/cortex/raw/pop_the_bubbles.py
@@ -1,7 +1,5 @@
 """ Module for raw feature pop_the_bubbles """
-import LAMP
 from ..feature_types import raw_feature
-
 
 @raw_feature(
     name="lamp.pop_the_bubbles",

--- a/cortex/raw/screen_state.py
+++ b/cortex/raw/screen_state.py
@@ -1,7 +1,6 @@
 """ Module for raw feature screen state """
 from ..feature_types import raw_feature
 
-
 @raw_feature(
     name="lamp.screen_state",
     dependencies=["lamp.screen_state"]

--- a/cortex/raw/sleep.py
+++ b/cortex/raw/sleep.py
@@ -1,7 +1,6 @@
 """ Module for raw feature sleep """
 from ..feature_types import raw_feature
 
-
 @raw_feature(
     name="lamp.sleep",
     dependencies=["lamp.sleep"]

--- a/cortex/raw/spatial_span.py
+++ b/cortex/raw/spatial_span.py
@@ -1,7 +1,5 @@
 """ Module for raw feature spatial_span """
-import LAMP
 from ..feature_types import raw_feature
-
 
 @raw_feature(
     name="lamp.spatial_span",

--- a/cortex/raw/steps.py
+++ b/cortex/raw/steps.py
@@ -1,7 +1,6 @@
 """ Module for raw feature steps """
 from ..feature_types import raw_feature
 
-
 @raw_feature(
     name="lamp.steps",
     dependencies=["lamp.steps"]

--- a/cortex/raw/survey.py
+++ b/cortex/raw/survey.py
@@ -1,7 +1,6 @@
 from ..feature_types import raw_feature, log
 import LAMP
 
-
 @raw_feature(
     name='lamp.survey',
     dependencies=['lamp.survey']
@@ -31,7 +30,7 @@ def survey(replace_ids=True,
                                                 _from=kwargs['start'],
                                                 to=kwargs['end'],
                                                 _limit=_limit)['data']
-    
+
     def remove_duplicate_activity_events(raw_data):
         # Here, we remove any duplicates from raw data
         # by generating a new list, then replacing the old one.
@@ -49,7 +48,7 @@ def survey(replace_ids=True,
                 # if we didn't find a duplicate, we just add the new event to the growing list
                 raw_minus_duplicates.append(event)
         return raw_minus_duplicates
-    
+
     raw = remove_duplicate_activity_events(raw)
 
     # Unpack the temporal slices and flatten the dict, including the timestamp and survey.

--- a/cortex/run.py
+++ b/cortex/run.py
@@ -74,13 +74,6 @@ def run(id_or_set, features=[], feature_params={}, start=None, end=None,
             run_part_and_features will take precendence and features will be
             set to [].
     """
-    # Connect to the LAMP API server.
-    if not 'LAMP_ACCESS_KEY' in os.environ or not 'LAMP_SECRET_KEY' in os.environ:
-        raise Exception("You configure `LAMP_ACCESS_KEY` and `LAMP_SECRET_KEY`"
-                        + " (and optionally `LAMP_SERVER_ADDRESS`) to use Cortex.")
-    LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
-                 os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
-
     if not print_logs:
         log.setLevel(logging.WARNING)
 

--- a/cortex/utils/db.py
+++ b/cortex/utils/db.py
@@ -253,13 +253,6 @@ def get_survey_names(participant_id, db="LAMP", client_url=None, client=None):
     if db not in client.list_database_names():
         raise KeyError(f'Could not find the {db} database. Did you mean one of {client.list_database_names()}')
 
-    # Connect to the LAMP API server.
-    if not 'LAMP_ACCESS_KEY' in os.environ or not 'LAMP_SECRET_KEY' in os.environ:
-        raise Exception("You configure `LAMP_ACCESS_KEY` and `LAMP_SECRET_KEY`" +
-                        " (and optionally `LAMP_SERVER_ADDRESS`) to use Cortex.")
-    LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
-                 os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
-
     df = LAMP.ActivityEvent.all_by_participant(participant_id, _limit=10000)["data"]
     df = pd.DataFrame(df)
     study_id = LAMP.Type.parent(participant_id)["data"]["Study"]

--- a/cortex/utils/module_scheduler.py
+++ b/cortex/utils/module_scheduler.py
@@ -6,8 +6,6 @@ import datetime
 import random
 import time
 import json
-LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
-        os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
 from ..utils.useful_functions import shift_time
 
 import os

--- a/cortex/utils/useful_functions.py
+++ b/cortex/utils/useful_functions.py
@@ -2,7 +2,6 @@ import os
 import LAMP
 from functools import reduce
 import pandas as pd
-LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'), os.getenv('LAMP_SERVER_ADDRESS'))
 import datetime
 
 

--- a/cortex/utils/useful_functions_misc.py
+++ b/cortex/utils/useful_functions_misc.py
@@ -2,7 +2,6 @@ import os
 import pandas as pd
 import numpy as np
 import LAMP
-LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'), os.getenv('LAMP_SERVER_ADDRESS'))
 
 def get_os_version(participant_id):
     """ Get OS / Device version from lamp.analytics data.

--- a/cortex/visualizations/correlation_functions.py
+++ b/cortex/visualizations/correlation_functions.py
@@ -5,8 +5,6 @@ import datetime
 import LAMP
 import numpy as np
 import pandas as pd
-LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
-            os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
 
 from ..utils.useful_functions import generate_ids, shift_time
 from ..primary.survey_scores import survey_scores

--- a/cortex/visualizations/data_quality.py
+++ b/cortex/visualizations/data_quality.py
@@ -423,13 +423,6 @@ def clear_chart(researcher_id, name):
 def data_quality(researcher_id):
     """ Function to create quality graphs for data monitoring.
     """
-    # Connect to LAMP
-    if not 'LAMP_ACCESS_KEY' in os.environ or not 'LAMP_SECRET_KEY' in os.environ:
-        raise Exception("You configure `LAMP_ACCESS_KEY` and `LAMP_SECRET_KEY`"
-                        + " (and optionally `LAMP_SERVER_ADDRESS`) to use Cortex.")
-    LAMP.connect(os.getenv('LAMP_ACCESS_KEY'), os.getenv('LAMP_SECRET_KEY'),
-                 os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital'))
-
     if len(researcher_id) == 0 or len(LAMP.Researcher.view(researcher_id)["data"]) == 0:
         log.warning('Invalid researcher id. Aborting.')
         return


### PR DESCRIPTION
To make the code more streamlined, we have removed `LAMP.connect()` from everywhere except feature_types.py. As part of the import block, this code will be run every time that cortex is imported. Environment variables are required to be set in order to run cortex.