### PR TITLE
Adding device_state

### DIFF
--- a/cortex/feature_types.py
+++ b/cortex/feature_types.py
@@ -335,24 +335,24 @@ def raw_feature(name, dependencies):
                                                         _limit=int(kwgs['_limit']))['data']
                 data += data_next
             # Special case for screen_ state and device state mapping to the same thing
-            if name == "lamp.screen_state":
+            if name == "lamp.device_state":
                 data_next = []
-                data_device_state = LAMP.SensorEvent.all_by_participant(kwgs['id'],
-                                               origin="lamp.device_state",
+                data_screen_state = LAMP.SensorEvent.all_by_participant(kwgs['id'],
+                                               origin="lamp.screen_state",
                                                _from=int(kwgs['start']),
                                                to=int(kwgs['end']),
                                                _limit=int(kwgs['_limit']))['data']
                 while (kwgs['recursive'] and
-                       (len(data_device_state) == MAX_RETURN_SIZE or
+                       (len(data_screen_state) == MAX_RETURN_SIZE or
                         len(data_next) == MAX_RETURN_SIZE)):
-                    to = data_device_state[-1]['timestamp']
+                    to = data_screen_state[-1]['timestamp']
                     data_next = LAMP.SensorEvent.all_by_participant(kwgs['id'],
-                                                            origin="lamp.device_state",
+                                                            origin="lamp.screen_state",
                                                             _from=int(kwgs['start']),
                                                             to=int(to),
                                                             _limit=int(kwgs['_limit']))['data']
-                    data_device_state += data_next
-                data += data_device_state
+                    data_screen_state += data_next
+                data += data_screen_state
             ret = [{'timestamp': x['timestamp'], **x['data']} for x in data]
             # Sort because of device_state / screen_state
             ret = (sorted(ret, key = lambda i: i['timestamp'], reverse=True))

--- a/cortex/raw/calls.py
+++ b/cortex/raw/calls.py
@@ -7,7 +7,7 @@ from ..feature_types import raw_feature
 )
 def calls(_limit=10000,
           cache=False,
-          recursive=False,
+          recursive=True,
           **kwargs):
     """ Get all call data bounded by the time interval.
 

--- a/cortex/raw/device_state.py
+++ b/cortex/raw/device_state.py
@@ -1,11 +1,11 @@
-""" Module for raw feature screen state """
+""" Module for raw feature device state """
 from ..feature_types import raw_feature
 
 @raw_feature(
-    name="lamp.screen_state",
-    dependencies=["lamp.screen_state"]
+    name="lamp.device_state",
+    dependencies=["lamp.device_state"]
 )
-def screen_state(_limit=10000,
+def device_state(_limit=10000,
                  cache=False,
                  recursive=True,
                  **kwargs):
@@ -19,18 +19,27 @@ def screen_state(_limit=10000,
 
     Returns:
         timestamp (int): The UTC timestamp for the screen_state event.
-        value OR state (int): 0, 1, 2, 3 to denote screen on, off, locked, charging**
-        valueString (str): "Screen On", "Screen Off", "Screen Locked"
+        value (int): 0, 1, 2, 3 to denote screen on, off, locked, charging**
+        representation (str): "screen_off", "screen_on", "locked", "unlocked"
     Note that based on phone type, value may be returned as "value" or as
             "state". Additionally, not all devices will return a "valueString".
     ** value / state are also phone dependent, so state = 0 on one phone could be the
         same as state = 1 on a different phone.
 
     Example:
-    [{'timestamp': 1618014245255, 'value': 1, 'valueString': 'Screen Off'},
-     {'timestamp': 1618014216292, 'value': 0, 'valueString': 'Screen On'},
-     {'timestamp': 1618013053261, 'value': 2, 'valueString': 'Screen Locked'},
-     {'timestamp': 1618013043261, 'value': 1, 'valueString': 'Screen Off'},
-     {'timestamp': 1618012058266, 'value': 0, 'valueString': 'Screen On'},]
+    [{'sensor': 'lamp.device_state',
+      'data': {
+          'value': 1,
+          'representation': 'screen_off',
+          'battery_level': 0.8999999761581421
+      },
+      'timestamp': 1650897192888},
+    {'sensor': 'lamp.device_state',
+     'data': {
+         'value': 0,
+         'representation': 'screen_on',
+         'battery_level': 0.9100000262260437
+      },
+      'timestamp': 1650896876889},]
     """
     return

--- a/cortex/raw/sleep.py
+++ b/cortex/raw/sleep.py
@@ -7,7 +7,7 @@ from ..feature_types import raw_feature
 )
 def sleep(_limit=10000,
           cache=False,
-          recursive=False,
+          recursive=True,
           **kwargs):
     """ Get all Healthkit sleep data bounded by time interval.
 

--- a/cortex/raw/sms.py
+++ b/cortex/raw/sms.py
@@ -7,7 +7,7 @@ from ..feature_types import raw_feature
 )
 def sms(_limit=10000,
         cache=False,
-        recursive=False,
+        recursive=True,
         **kwargs):
     """ Get all text messaging bounded by time interval.
 

--- a/cortex/raw/steps.py
+++ b/cortex/raw/steps.py
@@ -7,7 +7,7 @@ from ..feature_types import raw_feature
 )
 def steps(_limit=10000,
           cache=False,
-          recursive=False,
+          recursive=True,
           **kwargs):
     """ Get all step count bounded by time interval.
 

--- a/cortex/raw/telephony.py
+++ b/cortex/raw/telephony.py
@@ -7,7 +7,7 @@ from ..feature_types import raw_feature
 )
 def telephony(_limit=10000,
         cache=False,
-        recursive=False,
+        recursive=True,
         **kwargs):
     """ Get all telephony data bounded by time interval.
 

--- a/cortex/raw/wifi.py
+++ b/cortex/raw/wifi.py
@@ -7,7 +7,7 @@ from ..feature_types import raw_feature
 )
 def wifi(_limit=10000,
          cache=False,
-         recursive=False,
+         recursive=True,
          **kwargs):
     """ Get all wifi data bounded by time interval.
 

--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -47,6 +47,8 @@ echo "${green} calls.py ${reset}"
 pylint cortex/raw/calls.py
 echo "${green} cats_and_dogs.py ${reset}"
 pylint cortex/raw/cats_and_dogs.py
+echo "${green} device_state.py ${reset}"
+pylint cortex/raw/device_state.py
 echo "${green} gps.py ${reset}"
 pylint cortex/raw/gps.py
 echo "${green} gyroscope.py ${reset}"

--- a/tests/primary_feature_tests.py
+++ b/tests/primary_feature_tests.py
@@ -25,6 +25,8 @@ class TestPrimary(unittest.TestCase):
     TEST_SCREEN_ACTIVE_START_2 = 1585346933781
     TEST_SCREEN_ACTIVE_END_2 = TEST_SCREEN_ACTIVE_START_2 + 3 * MS_IN_DAY
     TEST_START_TIME_JERK = 1584137124130
+    TEST_PARTICIPANT_DEVICE = "U2913598741"
+    TEST_SCREEN_ACTIVE_START_3 = 1648050625957
 
     def setUp(self):
         """ Setup the tests """
@@ -234,16 +236,16 @@ class TestPrimary(unittest.TestCase):
         ret0 = primary.screen_active.screen_active(id=self.TEST_PARTICIPANT,
                                                    start=self.TEST_SCREEN_ACTIVE_START_0,
                                                    end=self.TEST_SCREEN_ACTIVE_END_0)
-        correct_dur = 600000
+        correct_dur = 599999
         self.assertEqual(ret0['data'][0]['duration'], correct_dur)
 
     def test_screenactive_correct_number(self):
         # Test if the number of bouts is correct
-        ret0 = primary.screen_active.screen_active(id=self.TEST_PARTICIPANT,
-                                                   start=self.TEST_SCREEN_ACTIVE_START_1,
-                                                   end=self.TEST_SCREEN_ACTIVE_END_1)
+        ret0 = primary.screen_active.screen_active(id=self.TEST_PARTICIPANT_DEVICE,
+                                                   start=self.TEST_SCREEN_ACTIVE_START_3,
+                                                   end=self.TEST_SCREEN_ACTIVE_START_3 + self.MS_IN_DAY)
         num_bouts = len(ret0['data'])
-        self.assertEqual(num_bouts, 7)
+        self.assertEqual(num_bouts, 76)
 
     # 3. Acc_jerk
     def test_acc_jerk_no_data(self):


### PR DESCRIPTION
Adding raw.device_state.

- screen_state is now deprecated. However, for backwards compatibility, pulling device_state data will also pull screen_state.
- Made raw.survey recursive.
- Added new tests for screen_active with new device_state data.
- Updated primary.screen_active to use the 'value' instead of 'state' key in accordance with device_state. Also removed the code to determine phone device type as the data should be the same across both now.
    - Left code to check for activities to determine when is "on" versus "off" for backwards compatibility. This should be removed in later versions.  