### PR TITLE
Fixing errors

### DIFF
--- a/cortex/secondary/data_quality.py
+++ b/cortex/secondary/data_quality.py
@@ -50,7 +50,7 @@ def data_quality(feature, bin_size=-1, **kwargs):
     else:
         log.info("This feature is not yet supported.")
         return {'timestamp':kwargs['start'], 'value': None}
-    number_of_bins = len(range(kwargs["start"], kwargs["end"], bin_size))
+    number_of_bins = len(range(kwargs["start"], kwargs["end"], bin_width))
 
     # check for the special case where there is no data
     if len(LAMP.SensorEvent.all_by_participant(participant_id=kwargs["id"],

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,7 +7,7 @@ find tests -name '*tests.py' -print0 |
         if [[ $line = "tests/primary_feature_tests.py" ]]
         then
             echo "${green} Running tests for ${line} ${reset}"
-            coverage run "$line"
+            coverage run -m unittest "$line"
             echo "${cyan} Coverage Report for ${line}"
             coverage report -m cortex/primary/significant_locations.py
             coverage report -m cortex/primary/trips.py
@@ -16,7 +16,7 @@ find tests -name '*tests.py' -print0 |
         elif [[ $line = "tests/secondary_feature_tests.py" ]]
         then
             echo "${green} Running tests for ${line} ${reset}"
-            coverage run "$line"
+            coverage run -m unittest "$line"
             echo "${cyan} Coverage Report for ${line}"
             coverage report -m cortex/secondary/bluetooth_device_count.py
             echo "${cyan} Coverage Report for ${line}"
@@ -26,7 +26,7 @@ find tests -name '*tests.py' -print0 |
         elif [[ $line = "tests/util_tests.py" ]]
         then
             echo "${green} Running tests for ${line} ${reset}"
-            coverage run "$line"
+            coverage run -m unittest "$line"
             echo "${cyan} Coverage Report for ${line}"
             coverage report -m cortex/utils/misc_functions.py
         else

--- a/tests/secondary_feature_tests.py
+++ b/tests/secondary_feature_tests.py
@@ -111,8 +111,8 @@ class TestSecondary(unittest.TestCase):
         self.assertEqual(ret0[1]['value'], None)
         self.assertEqual(ret0[2]['value'], None)
         self.assertEqual(ret0[3]['value'], 131120)
-        self.assertEqual(ret0[4]['value'], 179017)
-        self.assertEqual(ret0[5]['value'], 3598)
+        self.assertEqual(ret0[4]['value'], 179956)
+        self.assertEqual(ret0[5]['value'], 282319)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -2,10 +2,7 @@
 import unittest
 import sys
 import os
-import math
-import pandas as pd
 import logging
-import cortex
 import cortex.utils as utils
 import LAMP
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))


### PR DESCRIPTION
Fixing some errors (mostly related to the new updates).
- data_quality.py had a typo which is now fixed
- removed extra imports from util_tests.py
- Updated run_tests.sh to work with the new version of coverage
- Updated step_count tests to be correct

There are still some warnings from running unittests. These can be resolved in a separate PR if applicable, but for reference: 
- Resource warning: unclosed SSL socket
- Exception ignored on calling ctypes callback function (File "/opt/conda/lib/python3.8/site-packages/threadpoolctl.py)