### PR TITLE
Add device usage features

### DIFF
--- a/cortex/secondary/screen_unlock_duration.py
+++ b/cortex/secondary/screen_unlock_duration.py
@@ -18,8 +18,6 @@ def screen_unlock_duration(**kwargs):
                 for which the feature is being generated. Required.
             end (int): The last UNIX timestamp (in ms) of the window
                 for which the feature is being generated. Required.
-            incoming (boolean): If True the number of received calls
-                is returned; else the number of sent calls is returned.
 
     Returns:
         A dict consisting:

--- a/cortex/secondary/screen_unlock_duration.py
+++ b/cortex/secondary/screen_unlock_duration.py
@@ -1,0 +1,40 @@
+""" Module for screen_unlock_duration from raw device_usage """
+import numpy as np
+from ..feature_types import secondary_feature, log
+from ..raw.device_usage import device_usage
+
+MS_IN_A_DAY = 86400000
+@secondary_feature(
+    name='cortex.feature.screen_unlock_duration',
+    dependencies=[device_usage]
+)
+def screen_unlock_duration(**kwargs):
+    """Returns the amount of time the screen was unlocked.
+
+    Args:
+        **kwargs:
+            id (string): The participant's LAMP id. Required.
+            start (int): The initial UNIX timestamp (in ms) of the window
+                for which the feature is being generated. Required.
+            end (int): The last UNIX timestamp (in ms) of the window
+                for which the feature is being generated. Required.
+            incoming (boolean): If True the number of received calls
+                is returned; else the number of sent calls is returned.
+
+    Returns:
+        A dict consisting:
+            timestamp (int): The beginning of the window
+            (same as kwargs['start']).
+            value (float): The amount of time the screen was unlocked.
+    """
+    _screen_states = device_usage(**kwargs)['data']
+
+    screen_unlock_duration = np.sum(state['totalUnlockDuration'] for state in _screen_states)
+    
+    if len(_screen_states) == 0:
+        number = None
+
+    else:
+        number = screen_unlock_duration
+
+    return {'timestamp': kwargs['start'], 'value': number}

--- a/cortex/secondary/screen_unlocks.py
+++ b/cortex/secondary/screen_unlocks.py
@@ -1,0 +1,40 @@
+""" Module for screen_unlocks from raw device_usage """
+import numpy as np
+from ..feature_types import secondary_feature, log
+from ..raw.device_usage import device_usage
+
+MS_IN_A_DAY = 86400000
+@secondary_feature(
+    name='cortex.feature.screen_unlocks',
+    dependencies=[device_usage]
+)
+def screen_unlocks(**kwargs):
+    """Returns the number of times the screen was unlocked.
+
+    Args:
+        **kwargs:
+            id (string): The participant's LAMP id. Required.
+            start (int): The initial UNIX timestamp (in ms) of the window
+                for which the feature is being generated. Required.
+            end (int): The last UNIX timestamp (in ms) of the window
+                for which the feature is being generated. Required.
+            incoming (boolean): If True the number of received calls
+                is returned; else the number of sent calls is returned.
+
+    Returns:
+        A dict consisting:
+            timestamp (int): The beginning of the window
+            (same as kwargs['start']).
+            value (float): The number of screen unlocks.
+    """
+    _screen_states = device_usage(**kwargs)['data']
+
+    screen_unlock_count = np.sum(state['totalUnlocks'] for state in _screen_states)
+    
+    if len(_screen_states) == 0:
+        number = None
+
+    else:
+        number = screen_unlock_count
+
+    return {'timestamp': kwargs['start'], 'value': number}

--- a/cortex/secondary/screen_unlocks.py
+++ b/cortex/secondary/screen_unlocks.py
@@ -18,8 +18,6 @@ def screen_unlocks(**kwargs):
                 for which the feature is being generated. Required.
             end (int): The last UNIX timestamp (in ms) of the window
                 for which the feature is being generated. Required.
-            incoming (boolean): If True the number of received calls
-                is returned; else the number of sent calls is returned.
 
     Returns:
         A dict consisting:

--- a/cortex/secondary/screen_wakes.py
+++ b/cortex/secondary/screen_wakes.py
@@ -1,0 +1,40 @@
+""" Module for screen_wakes from raw device_usage """
+import numpy as np
+from ..feature_types import secondary_feature, log
+from ..raw.device_usage import device_usage
+
+MS_IN_A_DAY = 86400000
+@secondary_feature(
+    name='cortex.feature.screen_wakes',
+    dependencies=[device_usage]
+)
+def screen_wakes(**kwargs):
+    """Returns the number of times the screen woke up.
+
+    Args:
+        **kwargs:
+            id (string): The participant's LAMP id. Required.
+            start (int): The initial UNIX timestamp (in ms) of the window
+                for which the feature is being generated. Required.
+            end (int): The last UNIX timestamp (in ms) of the window
+                for which the feature is being generated. Required.
+            incoming (boolean): If True the number of received calls
+                is returned; else the number of sent calls is returned.
+
+    Returns:
+        A dict consisting:
+            timestamp (int): The beginning of the window
+            (same as kwargs['start']).
+            value (float): The number of screen wakes.
+    """
+    _screen_states = device_usage(**kwargs)['data']
+
+    screen_wake_count = np.sum(state['totalScreenWakes'] for state in _screen_states)
+    
+    if len(_screen_states) == 0:
+        number = None
+
+    else:
+        number = screen_wake_count
+
+    return {'timestamp': kwargs['start'], 'value': number}

--- a/cortex/secondary/screen_wakes.py
+++ b/cortex/secondary/screen_wakes.py
@@ -18,8 +18,6 @@ def screen_wakes(**kwargs):
                 for which the feature is being generated. Required.
             end (int): The last UNIX timestamp (in ms) of the window
                 for which the feature is being generated. Required.
-            incoming (boolean): If True the number of received calls
-                is returned; else the number of sent calls is returned.
 
     Returns:
         A dict consisting:


### PR DESCRIPTION
Added three new secondary cortex functions to capture additional device_usage data from Apple sensorkit (screen wake count, screen unlock count, screen unlock duration).