### PR TITLE
Add requests dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ seaborn = "^0.12.0"
 matplotlib = "^3.9.0"
 statsmodels = "^0.14.4"
 scipy = "^1.14.1"
+requests = "^2.16.2"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
For fresh installs of cortex in python 3.12, a few people ran into issues with the requests dependency. Adding it in explicitly. 