### PR TITLE
Drop dead tzwhere dep, remove unused fastdtw, bump Python floor to 3.10

### DIFF
--- a/cortex/participant_ext.py
+++ b/cortex/participant_ext.py
@@ -8,7 +8,6 @@ import sys
 import cortex
 import itertools
 from functools import reduce
-from tzwhere import tzwhere
 import pytz
 from dateutil.tz import tzlocal
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,13 @@ packages = [
 cortex = 'cortex.feature_types:_main'
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 LAMP-core = "^2021.5.18"
 DateTime = "^4.3"
 numpy = "^1.20.3"
 pandas = "^1.2.4"
 altair = "^4.1.0"
-tzwhere = "^3.0.3"
 geopy = "^2.1.0"
-fastdtw = "^0.3.4"
 scikit-learn = "^1.5.2"
 pytz = "^2021.1"
 compress-pickle = "^2.0.1"


### PR DESCRIPTION
The tzwhere dependency was the proximate cause of install failures on Python 3.11/3.12 (its old setup.py imports pkg_resources during build, which is no longer available by default in 3.12 build envs). It was only imported by cortex/participant_ext.py — an abandoned WIP module last meaningfully edited in March 2021, with no external callers anywhere in cortex. The using-method (timezone_correct) has been non-functional since it was written (undefined variables, removed pandas APIs); this PR leaves it as-is and just removes the import so the package installs.

fastdtw is removed because grep finds no imports of it anywhere in cortex/ — phantom dep.

The Python floor goes ^3.8 → ^3.10 to match transitive reality (scipy ^1.14 and scikit-learn ^1.5 already require ≥3.10). The previous ^3.8 declaration was the proximate cause of pip silently downgrading to 2021 cortex releases on modern Python.